### PR TITLE
[#9] fix : makeInput 함수 변경

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -6,4 +6,4 @@ module.exports = {
   arrowParens: 'avoid',
   endOfLine: 'auto',
   tabWidth: 2,
-};
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,10 +1,10 @@
-export const DEBUG = 0;
+export const DEBUG = 0
 
-export const MAX_SYMBOL_TABLE_SIZE = 1024;
-export const MEM_TEXT_START = 0x00400000;
-export const MEM_DATA_START = 0x10000000;
-export const BYTES_PER_WORD = 4;
-export const INST_LIST_LEN = 27;
+export const MAX_SYMBOL_TABLE_SIZE = 1024
+export const MEM_TEXT_START = 0x00400000
+export const MEM_DATA_START = 0x10000000
+export const BYTES_PER_WORD = 4
+export const INST_LIST_LEN = 27
 
 export const bcolors = {
   BLUE: '\x1B[34m',
@@ -12,37 +12,37 @@ export const bcolors = {
   GREEN: '\x1B[32m',
   RED: '\x1B[31m',
   ENDC: '\x1B[0m',
-};
+}
 
-const start = `[${bcolors.BLUE}START${bcolors.ENDC}]  `;
-const done = `[${bcolors.YELLOW}DONE${bcolors.ENDC}]  `;
-const success = `[${bcolors.GREEN}SUCCESS${bcolors.ENDC}]  `;
-const error = `[${bcolors.RED}ERROR${bcolors.ENDC}]  `;
+const start = `[${bcolors.BLUE}START${bcolors.ENDC}]  `
+const done = `[${bcolors.YELLOW}DONE${bcolors.ENDC}]  `
+const success = `[${bcolors.GREEN}SUCCESS${bcolors.ENDC}]  `
+const error = `[${bcolors.RED}ERROR${bcolors.ENDC}]  `
 
-export const pType = [start, done, success, error];
+export const pType = [start, done, success, error]
 // Structure Declaration
 
 export class instT {
   constructor(name, op, type, funct) {
-    this.name = name;
-    this.op = op;
-    this.type = type;
-    this.funct = funct;
+    this.name = name
+    this.op = op
+    this.type = type
+    this.funct = funct
   }
 }
 
 export class symbolT {
   constructor() {
-    this.name = 0;
-    this.address = 0;
+    this.name = 0
+    this.address = 0
   }
 }
 
 export class laStruct {
   constructor(op, rt, imm) {
-    this.op = op;
-    this.rt = rt;
-    this.imm = imm;
+    this.op = op
+    this.rt = rt
+    this.imm = imm
   }
 }
 
@@ -50,37 +50,37 @@ export const section = {
   DATA: 0,
   TEXT: 1,
   MAX_SIZE: 2,
-};
+}
 
 // Global Variable Declaration
 
-const ADD = new instT('add', '000000', 'R', '100000');
-const ADDI = new instT('addi', '001000', 'I', '');
-const ADDIU = new instT('addiu', '001001', 'I', '');
-const ADDU = new instT('addu', '000000', 'R', '100001');
-const AND = new instT('and', '000000', 'R', '100100');
-const ANDI = new instT('andi', '001100', 'I', '');
-const BEQ = new instT('beq', '000100', 'I', '');
-const BNE = new instT('bne', '000101', 'I', '');
-const J = new instT('j', '000010', 'J', '');
-const JAL = new instT('jal', '000011', 'J', '');
-const JR = new instT('jr', '000000', 'R', '001000');
-const LHU = new instT('lhu', '100101', 'I', '');
-const LUI = new instT('lui', '001111', 'I', '');
-const LW = new instT('lw', '100011', 'I', '');
-const NOR = new instT('nor', '000000', 'R', '100111');
-const OR = new instT('or', '000000', 'R', '100101');
-const ORI = new instT('ori', '001101', 'I', '');
-const SLT = new instT('slt', '000000', 'R', '101010');
-const SLTI = new instT('slti', '001010', 'I', '');
-const SLTIU = new instT('sltiu', '001011', 'I', '');
-const SLTU = new instT('sltu', '000000', 'R', '101011');
-const SLL = new instT('sll', '000000', 'R', '000000');
-const SRL = new instT('srl', '000000', 'R', '000010');
-const SH = new instT('sh', '101001', 'I', '');
-const SW = new instT('sw', '101011', 'I', '');
-const SUB = new instT('sub', '000000', 'R', '100010');
-const SUBU = new instT('subu', '000000', 'R', '100011');
+const ADD = new instT('add', '000000', 'R', '100000')
+const ADDI = new instT('addi', '001000', 'I', '')
+const ADDIU = new instT('addiu', '001001', 'I', '')
+const ADDU = new instT('addu', '000000', 'R', '100001')
+const AND = new instT('and', '000000', 'R', '100100')
+const ANDI = new instT('andi', '001100', 'I', '')
+const BEQ = new instT('beq', '000100', 'I', '')
+const BNE = new instT('bne', '000101', 'I', '')
+const J = new instT('j', '000010', 'J', '')
+const JAL = new instT('jal', '000011', 'J', '')
+const JR = new instT('jr', '000000', 'R', '001000')
+const LHU = new instT('lhu', '100101', 'I', '')
+const LUI = new instT('lui', '001111', 'I', '')
+const LW = new instT('lw', '100011', 'I', '')
+const NOR = new instT('nor', '000000', 'R', '100111')
+const OR = new instT('or', '000000', 'R', '100101')
+const ORI = new instT('ori', '001101', 'I', '')
+const SLT = new instT('slt', '000000', 'R', '101010')
+const SLTI = new instT('slti', '001010', 'I', '')
+const SLTIU = new instT('sltiu', '001011', 'I', '')
+const SLTU = new instT('sltu', '000000', 'R', '101011')
+const SLL = new instT('sll', '000000', 'R', '000000')
+const SRL = new instT('srl', '000000', 'R', '000010')
+const SH = new instT('sh', '101001', 'I', '')
+const SW = new instT('sw', '101011', 'I', '')
+const SUB = new instT('sub', '000000', 'R', '100010')
+const SUBU = new instT('subu', '000000', 'R', '100011')
 
 const instList = [
   ADD,
@@ -110,8 +110,8 @@ const instList = [
   SW,
   SUB,
   SUBU,
-];
+]
 
 // Global symbol table
-export const symbolStruct = new symbolT();
-export const SYMBOL_TABLE = new Array(MAX_SYMBOL_TABLE_SIZE);
+export const symbolStruct = new symbolT()
+export const SYMBOL_TABLE = new Array(MAX_SYMBOL_TABLE_SIZE)

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,47 +1,57 @@
-import {pType} from './constants.js';
-import * as fs from 'fs';
-import path from 'path';
+import { pType } from './constants.js'
+import * as fs from 'fs'
+import path from 'path'
 
 export function numToBits(num) {
   // 10진수 정수를 2진수 bit로 변경해서 return
-  let bits;
-  return bits;
+  let bits
+  return bits
 }
 
 export function log(printType, content) {
-  console.log(pType[printType] + content);
+  console.log(pType[printType] + content)
 }
 
 // Check the value is empty or not
 export function isEmpty(value) {
-  if (value === '' || value === null || value === undefined || (value !== null && typeof value === 'object' && !Object.keys(value).length) || value === ['']) {
-    return true;
+  if (
+    value === '' ||
+    value === null ||
+    value === undefined ||
+    (value !== null &&
+      typeof value === 'object' &&
+      !Object.keys(value).length) ||
+    value === ['']
+  ) {
+    return true
   } else {
-    return false;
+    return false
   }
 }
 
 // Parsing an assembly file(*.s) into a list
 export function makeInput(inputFolderName, inputFileName) {
-
-  const currDirectory = process.cwd();
-  const inputFilePath = path.join(currDirectory, inputFolderName, inputFileName);
+  const currDirectory = process.cwd()
+  const inputFilePath = path.join(currDirectory, inputFolderName, inputFileName)
 
   try {
     if (fs.existsSync(inputFilePath) === false) {
-      log(3, `No input file ${inputFileName} exists. Please check the file name and path.`);
-      process.exit(1);
+      log(
+        3,
+        `No input file ${inputFileName} exists. Please check the file name and path.`,
+      )
+      process.exit(1)
     }
 
-    const input = fs.readFileSync(inputFilePath, 'utf-8');
-    
+    const input = fs.readFileSync(inputFilePath, 'utf-8')
+
     if (isEmpty(input)) {
-      log(3, `input file ${inputFileName} is not opened. Please check the file`);
-      process.exit(1);
+      log(3, `input file ${inputFileName} is not opened. Please check the file`)
+      process.exit(1)
     }
 
-    return input.split('\n');
+    return input.split('\n')
   } catch (err) {
-    console.error(err);
+    console.error(err)
   }
 }

--- a/src/utils/state.js
+++ b/src/utils/state.js
@@ -1,10 +1,10 @@
 // For indexing of symbol table
-export let symbolTableCurIndex = 0;
+export let symbolTableCurIndex = 0
 
 // Temporary file stream pointers
-export let dataSeg;
-export let textSeg;
+export let dataSeg
+export let textSeg
 
 // Size of each section
-export let dataSectionSize = 0;
-export let textSectionSize = 0;
+export let dataSectionSize = 0
+export let textSectionSize = 0

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,10 +1,10 @@
-import {assemble} from '../main.js';
-import {bcolors} from '../src/utils/constants.js';
-import {makeInput} from '../src/utils/functions.js';
+import { assemble } from '../main.js'
+import { bcolors } from '../src/utils/constants.js'
+import { makeInput } from '../src/utils/functions.js'
 
-const inputFolderName = 'sample_input';
-const inputFileName = 'example1.s';
-const input = makeInput(inputFolderName, inputFileName); 
+const inputFolderName = 'sample_input'
+const inputFileName = 'example1.s'
+const input = makeInput(inputFolderName, inputFileName)
 
 const testOutput = `00000000000000000000000001011000
 00000000000000000000000000001100
@@ -33,15 +33,15 @@ const testOutput = `00000000000000000000000001011000
 00000000000000000000000001100100
 00000000000000000000000011001000
 00010010001101000101011001111000
-`;
-const output = assemble(input);
+`
+const output = assemble(input)
 
-export const test = output => {
-  console.log('\n-------------RESULT-------------');
-  console.log(`[${bcolors.YELLOW}TEST OUTPUT${bcolors.ENDC}]  `);
-  console.log(testOutput);
-  console.log(`[${bcolors.GREEN}YOUR OUTPUT${bcolors.ENDC}]  `);
-  console.log(output);
-};
+export const test = (output) => {
+  console.log('\n-------------RESULT-------------')
+  console.log(`[${bcolors.YELLOW}TEST OUTPUT${bcolors.ENDC}]  `)
+  console.log(testOutput)
+  console.log(`[${bcolors.GREEN}YOUR OUTPUT${bcolors.ENDC}]  `)
+  console.log(output)
+}
 
-test(output);
+test(output)


### PR DESCRIPTION
## ISSUE <#9> {[Feature] Parsing an assembly file(*.s) into a list}
assembly file (*.s)가 들어왔을 때 list 형태로 변환하는 함수 작성


<br>

## CHANGES
***functions.js***
1. 예외 처리 부분 추가
→ try ~ catch +  1. 파일 경로가 존재하지 않을 때 2. 파일 경로가 존재하지만 내용이 없을 때 에러처리 하였다.

2. 파일 위치 찾는 방법 변경 
→ 기존에는 직접 상대적 파일 경로를 입력해야 했다 ⇢ 현재 Directory를 기준으로 폴더경로와 파일이름만 쓰면 되게끔 변경
→ ex) 기존에는 tests/test.js을 기준으로 './sample_input/example1.s'를 parameter로 보내줘야 했다면,  현재는 'sample_input' , 'example1.s' 을 보내면 된다. 만약 폴더경로가 sample_input 안에 sample 폴더를 사용하고 싶다면, 'sample_input/sample' 만 입력해도 되서 편할 것 같아서 추가

***test.js***

→ makeInput 함수의 parameter 넣는 방식이 달라짐에 따라 변경하였다.
makeInput('./sample_input/example1.s') ⇢ makeInput(inputFolderName, inputFileName)

<br>

## TEST
어떤 부분을 테스트 해보면 좋을지 어떻게 테스트하면 되는지 간단하게 설명해주세요

## EX
예시 사진이 있다면 여기에 첨부해주세요
