### PR TITLE
[#19] feat : inputParsing시 발생할 수 있는 Error cases 처리 추가

### DIFF
--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,5 +1,6 @@
 import {DEBUG, pType, SYMBOL_TABLE} from './constants.js';
 import * as fs from 'fs';
+import path from 'path';
 
 export function numToBits(num) {
   // 10진수 정수를 2진수 bit로 변경해서 return
@@ -7,19 +8,19 @@ export function numToBits(num) {
   return bits;
 }
 
-export function toHexAndPad(num, pad = 8) { 
+export function toHexAndPad(num, pad = 8) {
   /*
-  * num : Number or String(숫자 형식, 10진법), pad : Number
-  * input : 18 => output: '00000012'
-  * Recommend | num을 Number 타입으로 넣을 것
-  */
-  return Number(num).toString(16).padStart(pad, '0'); 
+   * num : Number or String(숫자 형식, 10진법), pad : Number
+   * input : 18 => output: '00000012'
+   * Recommend | num을 Number 타입으로 넣을 것
+   */
+  return Number(num).toString(16).padStart(pad, '0');
 }
 
 export function symbolTableAddEntry(symbol) {
   SYMBOL_TABLE[symbol.name] = symbol.address;
   if (DEBUG) {
-    log(1, `${symbol.name}: 0x${toHexAndPad(symbol.address)}`)
+    log(1, `${symbol.name}: 0x${toHexAndPad(symbol.address)}`);
   }
 }
 
@@ -27,11 +28,54 @@ export function log(printType, content) {
   console.log(pType[printType] + content);
 }
 
+// Check the value is empty or not
+export function isEmpty(value) {
+  if (
+    value === '' ||
+    value === null ||
+    value === undefined ||
+    (value !== null &&
+      typeof value === 'object' &&
+      !Object.keys(value).length) ||
+    value === ['']
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 // Parsing an assembly file(*.s) into a list
-export function makeInput(path) {
+export function makeInput(inputFolderName, inputFileName) {
+  const currDirectory = process.cwd();
+  const inputFilePath = path.join(
+    currDirectory,
+    inputFolderName,
+    inputFileName,
+  );
+
+  console.log(currDirectory);
+
   try {
-    const input = fs.readFileSync(path, 'utf-8').split('\n');
-    return input;
+    if (fs.existsSync(inputFilePath) === false) {
+      log(
+        3,
+        `No input file ${inputFileName} exists. Please check the file name and path.`,
+      );
+      process.exit(1);
+    }
+
+    const input = fs.readFileSync(inputFilePath, 'utf-8');
+
+    if (isEmpty(input)) {
+      log(
+        3,
+        `input file ${inputFileName} is not opened. Please check the file`,
+      );
+      process.exit(1);
+    }
+
+    return input.split('\n');
   } catch (err) {
     console.error(err);
   }

--- a/tests/test.js
+++ b/tests/test.js
@@ -2,7 +2,9 @@ import {assemble} from '../main.js';
 import {bcolors} from '../src/utils/constants.js';
 import {makeInput} from '../src/utils/functions.js';
 
-const input = makeInput("./sample_input/example1.s")
+const inputFolderPath = 'sample_input';
+const inputFileName = 'example1.s';
+const input = makeInput(inputFolderPath, inputFileName);
 
 const testOutput = `00000000000000000000000001011000
 00000000000000000000000000001100


### PR DESCRIPTION
## ISSUE <#19> {[Feature] Parsing assembly file (*.s) into list}
어셈블리 파일을 리스트로 변환
기존에 없던 Error case들 추가 (Error messages 추가)



<br>

## CHANGES
- try ~ catch로 Error 관리 추가
- 파일 경로가 존재하지 않을 때 Error message 추가
- 파일 경로는 존재하지만, 내용이 없을 때 Error message 추가


<br>

## TEST
어떤 부분을 테스트 해보면 좋을지 어떻게 테스트하면 되는지 간단하게 설명해주세요

## EX
- 파일 경로가 존재하지 않을 때때
<img width="1440" alt="Screen Shot 2022-12-31 at 3 49 43 PM" src="https://user-images.githubusercontent.com/99087502/210128041-5c500221-080c-41ce-a1dd-3c10610539f3.png">

- 파일이 비어있을 때, 
<img width="1440" alt="Screen Shot 2022-12-31 at 3 50 40 PM" src="https://user-images.githubusercontent.com/99087502/210128058-7051ab25-f5b1-421a-8acd-d51b515b4a1a.png">
