### PR TITLE
[#27] FIX : makeInput 함수 Error 관리 변경

### DIFF
--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -29,16 +29,62 @@ export function log(printType, content) {
   console.log(pType[printType] + content);
 }
 
-// Parsing an assembly file(*.s) into a list
-export function makeInput(path) {
-  try {
-    const input = fs.readFileSync(path, 'utf-8').split('\n');
-    return input;
-  } catch (err) {
-    console.error(err);
+// Check the value is empty or not
+export function isEmpty(value) {
+  if (
+    value === '' ||
+    value === null ||
+    value === undefined ||
+    (value !== null &&
+      typeof value === 'object' &&
+      !Object.keys(value).length) ||
+    value === ['']
+  ) {
+    return true;
+  } else {
+    return false;
   }
 }
 
+// Parsing an assembly file(*.s) into a list
+export function makeInput(inputFolderName, inputFileName) {
+  /*
+   if the inputFilePath is /Users/junghaejune/simulator/sample_input/sample/example1.s,
+    currDirectory : /Users/junghaejune/simulator
+    inputFolderPath : sample_input/sample
+    inputFileName: example1.s
+  */
+
+  const currDirectory = process.cwd();
+  const inputFilePath = path.join(
+    currDirectory,
+    inputFolderName,
+    inputFileName,
+  );
+
+  try {
+    if (fs.existsSync(inputFilePath) === false) throw 'INPUT_PATH_ERROR';
+
+    const input = fs.readFileSync(inputFilePath, 'utf-8');
+
+    if (isEmpty(input)) throw 'INPUT_EMPTY';
+
+    return input.split('\n');
+  } catch (err) {
+    if (err === 'INPUT_PATH_ERROR') {
+      log(
+        3,
+        `No input file ${inputFileName} exists. Please check the file name and path.`,
+      );
+    } else if (err === 'INPUT_EMPTY') {
+      log(
+        3,
+        `input file ${inputFileName} is not opened. Please check the file`,
+      );
+    } else console.error(err);
+    exit(1);
+  }
+}
 // Create an Object file(*.o) in the desired path
 export function makeObjectFile(outputFolderPath, outputFileName, content) {
   /*


### PR DESCRIPTION
## ISSUE <#27> {[FIX} : makeInput 함수 Error 관리}
makeInput 함수 Error 관리할 때, 
console.log -> throw error명을 통해 catch로 error확인


<br>

## CHANGES
기존에는 try문에서 if문을 통해 console.log( error message)
→ try문에서는 throw로 error 잡아내고 catch문에서 error message를 날리도록 변경
→ error message를 날린 후에는 프로그램을 종료하도록 함

<br>

## TEST
어떤 부분을 테스트 해보면 좋을지 어떻게 테스트하면 되는지 간단하게 설명해주세요

## EX

![Screen Shot 2023-01-04 at 12 04 51 PM](https://user-images.githubusercontent.com/99087502/210476720-bb6a7a3c-4cd9-43ed-b5f1-5131ae6a65a8.png)

예시 사진이 있다면 여기에 첨부해주세요
![Screen Shot 2023-01-04 at 12 03 23 PM](https://user-images.githubusercontent.com/99087502/210476623-8e1b417d-dbb0-4a38-b001-c0e0e19686a9.png)
