### PR TITLE
Feature/73/imporove simulator

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,12 +1,6 @@
 import {makeBinaryFile, makeBinaryObject} from './src/simulator/assembler';
 import {CYCLES, initialize, initializeMem} from './src/utils/constants';
-import {
-  mainProcess,
-  makeInput,
-  makeOutput,
-  parseSimulatorOutput,
-  simulatorUnitTest,
-} from './src/utils/functions';
+import {mainProcess} from './src/utils/functions';
 
 export function assemble(assemblyFile: string[]): string {
   const {dataSectionSize, textSectionSize, binaryText, binaryData} =
@@ -29,6 +23,7 @@ export function simulator(
 ): object {
   const {dataSectionSize, textSectionSize, binaryText, binaryData} =
     makeBinaryObject(assemblyFile);
+
   initializeMem();
   const {INST_INFO} = initialize(
     binaryText.concat(binaryData),
@@ -39,4 +34,3 @@ export function simulator(
   const output = mainProcess(INST_INFO, cycle);
   return returnCycles ? {output, cycles: CYCLES} : output;
 }
-console.log(simulator(makeInput('sample_input', 'example1.s'), 10000));

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,12 @@
 import {makeBinaryFile, makeBinaryObject} from './src/simulator/assembler';
-import {initialize} from './src/utils/constants';
-import {mainProcess} from './src/utils/functions';
+import {CYCLES, initialize, initializeMem} from './src/utils/constants';
+import {
+  mainProcess,
+  makeInput,
+  makeOutput,
+  parseSimulatorOutput,
+  simulatorUnitTest,
+} from './src/utils/functions';
 
 export function assemble(assemblyFile: string[]): string {
   const {dataSectionSize, textSectionSize, binaryText, binaryData} =
@@ -19,7 +25,7 @@ export function assemble(assemblyFile: string[]): string {
 export function simulator(assemblyFile: string[], cycle: number): string {
   const {dataSectionSize, textSectionSize, binaryText, binaryData} =
     makeBinaryObject(assemblyFile);
-
+  initializeMem();
   const {INST_INFO} = initialize(
     binaryText.concat(binaryData),
     textSectionSize,
@@ -28,4 +34,14 @@ export function simulator(assemblyFile: string[], cycle: number): string {
 
   const output: string = mainProcess(INST_INFO, cycle);
   return output;
+}
+
+for (let i = 3; i <= 3; i++) {
+  console.log(`testing example ${i}`);
+  simulator(makeInput('sample_input', `example${i}.s`), 10000);
+  const testOutput = parseSimulatorOutput(
+    makeOutput('simulator_sample_output', `example0${i}.o`),
+  );
+  const output = parseSimulatorOutput(CYCLES[CYCLES.length - 1]);
+  simulatorUnitTest(testOutput, output);
 }

--- a/main.ts
+++ b/main.ts
@@ -26,7 +26,7 @@ export function simulator(
   assemblyFile: string[],
   cycle: number,
   returnCycles = false,
-): string | object {
+): object {
   const {dataSectionSize, textSectionSize, binaryText, binaryData} =
     makeBinaryObject(assemblyFile);
   initializeMem();
@@ -38,14 +38,4 @@ export function simulator(
 
   const output = mainProcess(INST_INFO, cycle);
   return returnCycles ? {output, cycles: CYCLES} : output;
-}
-
-for (let i = 1; i <= 7; i++) {
-  console.log(`testing example ${i}`);
-  simulator(makeInput('sample_input', `example${i}.s`), 10000);
-  const testOutput = parseSimulatorOutput(
-    makeOutput('simulator_sample_output', `example0${i}.o`),
-  );
-  const output = parseSimulatorOutput(CYCLES[CYCLES.length - 1]);
-  simulatorUnitTest(testOutput, output);
 }

--- a/main.ts
+++ b/main.ts
@@ -39,3 +39,4 @@ export function simulator(
   const output = mainProcess(INST_INFO, cycle);
   return returnCycles ? {output, cycles: CYCLES} : output;
 }
+console.log(simulator(makeInput('sample_input', 'example1.s'), 10000));

--- a/main.ts
+++ b/main.ts
@@ -22,7 +22,11 @@ export function assemble(assemblyFile: string[]): string {
   return output;
 }
 
-export function simulator(assemblyFile: string[], cycle: number): string {
+export function simulator(
+  assemblyFile: string[],
+  cycle: number,
+  returnCycles = false,
+): string | object {
   const {dataSectionSize, textSectionSize, binaryText, binaryData} =
     makeBinaryObject(assemblyFile);
   initializeMem();
@@ -32,11 +36,11 @@ export function simulator(assemblyFile: string[], cycle: number): string {
     dataSectionSize,
   );
 
-  const output: string = mainProcess(INST_INFO, cycle);
-  return output;
+  const output = mainProcess(INST_INFO, cycle);
+  return returnCycles ? {output, cycles: CYCLES} : output;
 }
 
-for (let i = 3; i <= 3; i++) {
+for (let i = 1; i <= 7; i++) {
   console.log(`testing example ${i}`);
   simulator(makeInput('sample_input', `example${i}.s`), 10000);
   const testOutput = parseSimulatorOutput(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,11 @@
-import {initMemory, initInstInfo, parseInstr, parseData} from './functions';
+import {
+  initMemory,
+  initInstInfo,
+  parseInstr,
+  parseData,
+  parseSimulatorOutput,
+  simulatorOutputType,
+} from './functions';
 
 export const DEBUG = 0;
 export const MAX_SYMBOL_TABLE_SIZE = 1024;
@@ -33,7 +40,7 @@ export let memStack: memRegionT;
 export let memRegions: memRegionT[];
 export let currentState: cpuState;
 
-export const CYCLES: string[] = [];
+export const CYCLES: simulatorOutputType[] = [];
 
 export let NUM_INST: number;
 
@@ -325,5 +332,5 @@ export const changeRunBit = () => {
 };
 
 export const pushCycle = (eachCycle: string) => {
-  CYCLES.push(eachCycle);
+  CYCLES.push(parseSimulatorOutput(eachCycle));
 };

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -519,7 +519,7 @@ export function getInstInfo(pc: number): instruction {
   Procedure: main process
 */
 
-export function mainProcess(INST_INFO: instruction[], cycles: number): string {
+export function mainProcess(INST_INFO: instruction[], cycles: number): object {
   let i = cycles;
   let result = '';
   if (DEBUG_SET) {
@@ -536,7 +536,7 @@ export function mainProcess(INST_INFO: instruction[], cycles: number): string {
       if (RUN_BIT === 0) break;
     }
   } else {
-    result += running(i);
+    running(i);
     result += rdump();
 
     if (MEM_DUMP_SET) {
@@ -547,8 +547,8 @@ export function mainProcess(INST_INFO: instruction[], cycles: number): string {
     if (MEM_DUMP_SET) EachCycle += dumpMemory();
     pushCycle(EachCycle);
   }
-
-  return result;
+  const returnObject = parseSimulatorOutput(result);
+  return returnObject;
 }
 
 /*
@@ -623,11 +623,11 @@ export function rdump(): string {
   Procedure: run n
   Purpose: Simulate MIPS for n cycles
 */
-export function running(num_cycles: number): string {
+export function running(num_cycles: number) {
   let running_string = '';
   if (RUN_BIT === 0) {
     running_string = "Can't simulate, Simulator is halted\n";
-    return running_string;
+    //console.log(running_string);
   }
 
   running_string = `Simulating for ${num_cycles} cycles...\n\n`;
@@ -643,5 +643,5 @@ export function running(num_cycles: number): string {
     cycle();
   }
 
-  return running_string;
+  console.log(running_string);
 }

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -543,7 +543,10 @@ export function getInstInfo(pc: number): instruction {
   Procedure: main process
 */
 
-export function mainProcess(INST_INFO: instruction[], cycles: number): object {
+export function mainProcess(
+  INST_INFO: instruction[],
+  cycles: number,
+): simulatorOutputType {
   let i = cycles;
   let result = '';
   if (DEBUG_SET) {

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -262,7 +262,9 @@ export function parseSimulatorOutput(rawOutput: string): object {
 
   function splitHelper(input: string): [string, string] {
     const returnValue = input.split(/:|\n/);
-    return [returnValue[0], returnValue[1].trim()];
+    return returnValue.length === 2
+      ? [returnValue[0], returnValue[1].trim()]
+      : null;
   }
 
   function setTypeParser(input: string): object {
@@ -272,7 +274,7 @@ export function parseSimulatorOutput(rawOutput: string): object {
       .filter(e => e !== '')
       .map(element => {
         const result = splitHelper(element);
-        returnSet[result[0]] = result[1];
+        result ? (returnSet[result[0]] = result[1]) : null;
       });
 
     return returnSet;

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -38,7 +38,7 @@ import {
 } from '../simulator/run';
 
 export interface simulatorOutputType {
-  PC: {[key: string]: string};
+  PC: string;
   registers: {[key: string]: string};
   dataSection: {[key: string]: string} | Record<string, never>;
   stackSection: {[key: string]: string} | Record<string, never>;
@@ -260,8 +260,16 @@ export function simulatorUnitTest(
       }
     });
   }
-  type keyType = 'PC' | 'registers' | 'dataSection' | 'stackSection';
-  const keyList: keyType[] = ['PC', 'registers', 'dataSection', 'stackSection'];
+
+  type keyType = 'registers' | 'dataSection' | 'stackSection';
+  const keyList: keyType[] = ['registers', 'dataSection', 'stackSection'];
+
+  console.log(`---------------PC---------------`);
+  console.log(
+    `${testCase.PC === output.PC ? bcolors.GREEN : bcolors.RED}PC : ${
+      testCase.PC
+    }          PC : ${output.PC}${bcolors.ENDC}\n`,
+  );
 
   keyList.map(key => {
     console.log(`---------------${key}---------------`);
@@ -305,7 +313,7 @@ export function parseSimulatorOutput(rawOutput: string): simulatorOutputType {
   const dataSection = setTypeParser(outputList[2] || '');
   const stackSection = setTypeParser(outputList[3] || '');
 
-  return {PC, registers, dataSection, stackSection};
+  return {PC: PC.PC, registers, dataSection, stackSection};
 }
 
 export function makeOutput(

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -37,8 +37,14 @@ import {
   setTARGET,
 } from '../simulator/run';
 
+export interface simulatorOutputType {
+  PC: {[key: string]: string};
+  registers: {[key: string]: string};
+  dataSection: {[key: string]: string} | Record<string, never>;
+  stackSection: {[key: string]: string} | Record<string, never>;
+}
+
 export function parseInstr(buffer: string, index: number): instruction {
-  //[TODO] Implement this function
   const instr: instruction = new instruction();
 
   setOPCODE(instr, fromBinary(buffer.slice(0, 6)));
@@ -234,8 +240,14 @@ export function makeInput(
   }
 }
 
-export function simulatorUnitTest(testCase: object, output: object) {
-  function printResult(origin: object, compare: object) {
+export function simulatorUnitTest(
+  testCase: simulatorOutputType,
+  output: simulatorOutputType,
+) {
+  function printResult(
+    origin: {[key: string]: string} | Record<string, never>,
+    compare: {[key: string]: string} | Record<string, never>,
+  ) {
     Object.keys(origin).map(key => {
       if (compare[key]) {
         const color =
@@ -248,15 +260,17 @@ export function simulatorUnitTest(testCase: object, output: object) {
       }
     });
   }
+  type keyType = 'PC' | 'registers' | 'dataSection' | 'stackSection';
+  const keyList: keyType[] = ['PC', 'registers', 'dataSection', 'stackSection'];
 
-  ['PC', 'registers', 'dataSection', 'stackSection'].map(type => {
-    console.log(`---------------${type}---------------`);
-    printResult(testCase[type], output[type]);
+  keyList.map(key => {
+    console.log(`---------------${key}---------------`);
+    printResult(testCase[key], output[key]);
     console.log('\n');
   });
 }
 
-export function parseSimulatorOutput(rawOutput: string): object {
+export function parseSimulatorOutput(rawOutput: string): simulatorOutputType {
   //input : test simulator input
   //ouput : object type -> { register : {PC:, R0:,...}, dataSection:{}, stackSection{}}
 
@@ -267,7 +281,9 @@ export function parseSimulatorOutput(rawOutput: string): object {
       : null;
   }
 
-  function setTypeParser(input: string): object {
+  function setTypeParser(
+    input: string,
+  ): {[key: string]: string} | Record<string, never> {
     const returnSet = {};
     input
       .split(/\n/)

--- a/tests/integration/simulator.test.ts
+++ b/tests/integration/simulator.test.ts
@@ -14,7 +14,7 @@ for (let i = 1; i <= 7; i++) {
     const expectOutput = parseSimulatorOutput(
       makeOutput('simulator_sample_output', `example0${i}.o`),
     );
-    const testOutput = parseSimulatorOutput(CYCLES[CYCLES.length - 1]);
+    const testOutput = CYCLES[CYCLES.length - 1];
     expect(expectOutput.toString()).toBe(testOutput.toString());
   });
 }


### PR DESCRIPTION
## ISSUE <#73> {improve simulator}
저번 회의에서 나온 기능 추가


<br>

## CHANGES
어떤 코드를 만들었는지 혹은 어떤 코드를 수정해서 문제를 해결했는지 적어주세요.
1. returncycle 옵션 추가. Default 는 fasle로 CYCLES를 리턴 하지 않지만, true로 설정할 경우 리턴한다.
2. MainProcess 리턴 직전 ParseSimulatorOutput함수 이용해서 string 아웃품 object 형태로 변환
3. 타입 이슈 해결


<br>

## TEST
어떤 부분을 테스트 해보면 좋을지 어떻게 테스트하면 되는지 간단하게 설명해주세요.
`console.log(simulator(makeInput('sample_input', `example1.s`), 10000, true));`
로 정상 작동되는지, Object 형태로 리턴되는지, CYCLE이 함께 나오는지 확인해주세요.

** 추가적으로 회의에서 나온 기능이 모두 반영되었는지 더블 체크 부탁드립니다. **

<br>

## FYI

**String Literal**

이번 타입에러를 해결하면서 너무 많은 똥꼬쇼를 하였다. 이를 정리할 겸 공유한다. 

```
interface simulatorOutputType {
  PC: {[key: string]: string};
  registers: {[key: string]: string};
  dataSection: {[key: string]: string} | Record<string, never>;
  stackSection: {[key: string]: string} | Record<string, never>;
}

['PC', 'registers', 'dataSection', 'stackSection'].map(key => {
    console.log(`---------------${key}---------------`);
    printResult(testCase[key], output[key]);
    console.log('\n');
  });
```

다음과 같은 코드에서 밑줄친곳에서 에러가 발생하였다. testCase, output 모두 simulatorOutputType 타입으로 잘 지정해줬다고 생각했는데 계속해서 에러가 발생했다. 

`printResult(testCase.PC, output.PC);` 로 하였을때는 문제없이 동작함을 발견하고 다이나믹 키와 관련된 타입 에러임을 알게되었다. 그래서 이를 clue삼아서 열심히 써치하였다.

타입 스크립트는 기본적으로 객체의 프로퍼티를 읽을때, string 타입의 key의 사용을 허용하지 않는다. string literal만 허용한다. 

**literal type**이란?

아래 코드에서 Food에서 허용한 3개의 문자열 외에 다른 문자열을 사용하게 되면 에러가 발생한다.

```
type Food = "rice" | "noodle" | "meat";

const myFood1: Food = "rice";
const myFood2: Food = "aaa";  // Error: Type 'aaa' is not assignable to type 'Food'.
```

숫자형도 마찬가지로 허용한 숫자 외에 다른 숫자를 사용하게 되면 에러 발생

```
type Grade = 1 | 2 | 3;

const student1: Grade = 1;
const student2: Grade = 5;
```

즉, 문자열이나 숫자에 정확한 값을 지정할 수가 있다.

타입스크립트에서 다이나믹 키로 들어올때 단순히 string으로 지정하면 에러가 발생한다. 따라서 key로 들어올 string 값을 지정해줘야한다.

다음과 같이 keyType의 이름으로 string literal을 지정해주고, keyType을 값으로 가지는 keyList를 만들어서 map을 돌리니 해결되었다.

```
type keyType = 'PC' | 'registers' | 'dataSection' | 'stackSection';
const keyList: keyType[] = ['PC', 'registers', 'dataSection', 'stackSection'];
```

코드를 최적화할때 객체의 키를 가지고 map을 돌리거나 접근을 해야하는 경우가 많은데 주의하도록 하자…

https://limetree-minji.notion.site/String-Literal-e905481af0d54eb39749a80f509ad375
