### PR TITLE
[#75] docs: readme에 react 사용 시 주의사항 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Currently, we support a function to convert an assembly file to a binary file. I
 
 ## Install
 
-    npm install --save mips-simulator
+    npm install --save mips-simulator-js
 
 ---
 
@@ -116,6 +116,64 @@ makeObjectFile(outputFolderPath, outputFileName, binary);
 <img src="https://user-images.githubusercontent.com/44657722/211183736-c79836ed-8922-4a80-aacd-2aef353098dd.png" width="48%"/> 
 <img src="https://user-images.githubusercontent.com/44657722/211183724-1fccb82f-bc03-4598-8d19-af0a5fc0e77e.png" width="45%"/> 
 </p>
+
+### Use for React/Next
+
+If you use this npm package in your `react` or `next` project, problems will occur in the 'fs', 'path', and 'process' parts that load files.
+<img width="1315" alt="reactError" src="https://user-images.githubusercontent.com/64965613/216809659-1dde2240-5461-45b2-948a-bff631e5c528.png">
+
+This problem is caused by the webpack version. For details, refer to the [**webpack official documentation**](https://webpack.kr/migrate/5/#upgrade-webpack-4-and-its-pluginsloaders).
+
+The solution is to change the webpack configuration to `false` as shown below and import the file using `fetch`.
+
+1. Change webpack config and package settings
+
+```js
+// node_modules/react-scripts/config/webpack.config.json
+module.exports = function (webpackEnv) {
+  // ...
+  return {
+   // ...
+		resolve: {
+			// ...
+			// Add This!👇
+			fallback: {
+        "fs": false,
+        "path": false,
+        "process": false,
+		  },
+			// ...
+}
+
+// package.json
+{
+	// ...
+  "dependencies": {},
+  "devDependencies": {},
+
+  // Add This👇️
+  "browser": {
+    "fs": false,
+    "os": false,
+    "path": false
+  }
+}
+```
+
+2. Creating a file calling function using fetch
+
+```js
+const fetchFile = async (filePath: string) => {
+  await fetch(filePath)
+    .then(response => response.text())
+    .then(text => {
+      // Create a function to use and put it here!
+    });
+};
+```
+
+\*_⚠️caution_
+In the browser, unlike in the local environment, only files or documents in the public path can be used, and the default path is automatically designated as public. Therefore, the assembly file to be converted into an object file using assembler must be stored in the public folder.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ module.exports = function (webpackEnv) {
         "process": false,
 		  },
 			// ...
+    }
+  }
 }
-
 // package.json
 {
 	// ...
@@ -177,7 +178,7 @@ const fetchFile = async (filePath: string) => {
 };
 ```
 
-#### ⚠️caution
+#### ⚠️Caution
 
 In the browser, unlike in the local environment, only files or documents in the public path can be used, and the default path is automatically designated as public. Therefore, the assembly file to be converted into an object file using assembler must be stored in the `public` folder.
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ makeObjectFile(outputFolderPath, outputFileName, binary);
 <img src="https://user-images.githubusercontent.com/44657722/211183724-1fccb82f-bc03-4598-8d19-af0a5fc0e77e.png" width="45%"/> 
 </p>
 
-### Use for React/Next
+## Usage for React/Next
 
-#### Problem
+### Problem
 
 If you use this npm package in your `react` or `next` project, problems will occur in the 'fs', 'path', and 'process' parts that load files.
 
@@ -127,7 +127,7 @@ If you use this npm package in your `react` or `next` project, problems will occ
 
 This problem is caused by the webpack version. For details, refer to the [**webpack official documentation**](https://webpack.kr/migrate/5/#upgrade-webpack-4-and-its-pluginsloaders).
 
-#### Solution
+### Solution
 
 The solution is to change the webpack configuration to `false` as shown below and import the file using `fetch`.
 
@@ -178,7 +178,7 @@ const fetchFile = async (filePath: string) => {
 };
 ```
 
-#### ⚠️Caution
+### ⚠️Caution
 
 In the browser, unlike in the local environment, only files or documents in the public path can be used, and the default path is automatically designated as public. Therefore, the assembly file to be converted into an object file using assembler must be stored in the `public` folder.
 

--- a/README.md
+++ b/README.md
@@ -138,16 +138,16 @@ The solution is to change the webpack configuration to `false` as shown below an
 module.exports = function (webpackEnv) {
   // ...
   return {
-   // ...
-		resolve: {
-			// ...
-			// Add This!👇
-			fallback: {
+    // ...
+    resolve: {
+      // ...
+      // Add This!👇
+      fallback: {
         "fs": false,
         "path": false,
         "process": false,
-		  },
-			// ...
+      },
+      // ...
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -119,10 +119,15 @@ makeObjectFile(outputFolderPath, outputFileName, binary);
 
 ### Use for React/Next
 
+#### Problem
+
 If you use this npm package in your `react` or `next` project, problems will occur in the 'fs', 'path', and 'process' parts that load files.
+
 <img width="1315" alt="reactError" src="https://user-images.githubusercontent.com/64965613/216809659-1dde2240-5461-45b2-948a-bff631e5c528.png">
 
 This problem is caused by the webpack version. For details, refer to the [**webpack official documentation**](https://webpack.kr/migrate/5/#upgrade-webpack-4-and-its-pluginsloaders).
+
+#### Solution
 
 The solution is to change the webpack configuration to `false` as shown below and import the file using `fetch`.
 
@@ -172,8 +177,9 @@ const fetchFile = async (filePath: string) => {
 };
 ```
 
-\*_⚠️caution_
-In the browser, unlike in the local environment, only files or documents in the public path can be used, and the default path is automatically designated as public. Therefore, the assembly file to be converted into an object file using assembler must be stored in the public folder.
+#### ⚠️caution
+
+In the browser, unlike in the local environment, only files or documents in the public path can be used, and the default path is automatically designated as public. Therefore, the assembly file to be converted into an object file using assembler must be stored in the `public` folder.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ module.exports = function (webpackEnv) {
 }
 ```
 
-2. Creating a file calling function using fetch
+2. Creating a file calling function using fetch (This function is a replacement for 'makeInput' provided by the library for use in `React` / `Next`.)
 
 ```js
 const fetchFile = async (filePath: string) => {
@@ -176,9 +176,34 @@ const fetchFile = async (filePath: string) => {
       // Create a function to use and put it here!
     });
 };
+
+// Example
+
+const [fileContent, setFileContent] = useState('');
+const [binaryInstruction, setBinaryInstruction] = useState<string[] | null>(
+    null
+  );
+
+useEffect(() => {
+  const fetchFile = async (filePath: string) => {
+    await fetch(filePath)
+      .then(response => response.text())
+      .then(text => {
+        setFileContent(text.split('\n'));
+      });
+  };
+  const filePath = `sample_input/example01.s`;
+  fetchFile(filePath);
+}, [setFileContent]);
+
+useEffect(() => {
+  if (fileContent)
+    setBinaryInstruction(assemble(fileContent).split("\n"));
+}, [fileContent]);
+
 ```
 
-### ⚠️Caution
+### ⚠️ Caution
 
 In the browser, unlike in the local environment, only files or documents in the public path can be used, and the default path is automatically designated as public. Therefore, the assembly file to be converted into an object file using assembler must be stored in the `public` folder.
 


### PR DESCRIPTION
react에서 해당 패키지 사용 시 webpack 문제로 path, fs, process 에러 발생하는 것에 대한 해결법 readme에 게시 Close #75

## ISSUE <#75>  readme에 react 사용 시 주의사항 추가
react에서 해당 패키지 사용 시 webpack 문제로 path, fs, process 에러 발생하는 것에 대한 해결법 readme에 게시

<br>

## CHANGES
1. 문제사항 게시 (webpack 관련 문제)
2. 해결법 제시(webpack 관련 설정 + fetch를 이용한 파일 호출)
3. 주의사항 (사용할 파일을 public 폴더에 넣을 것)


<br>

## TEST
`Files changed` 탭에서 README.md  에 대해서 view file 눌러서 내용 확인해주세요

## EX
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/64965613/216855541-c05826e3-83b7-45ef-a14b-b8428351594b.png">