### PR TITLE
[#85] fix : import 구문 정리

### DIFF
--- a/src/simulator/assembler.ts
+++ b/src/simulator/assembler.ts
@@ -1,15 +1,15 @@
 import {
-  section,
+  BYTES_PER_WORD,
+  instT,
+  instList,
   MEM_DATA_START,
   MEM_TEXT_START,
+  section,
   symbolT,
-  BYTES_PER_WORD,
   SYMBOL_TABLE,
-  instList,
-  instT,
   resetSymbolTable,
 } from '../utils/constants';
-import {symbolTableAddEntry, toHexAndPad, numToBits} from '../utils/functions';
+import {numToBits, symbolTableAddEntry, toHexAndPad} from '../utils/functions';
 
 export const makeSymbolTable = (inputs: string[]) => {
   /*

--- a/src/simulator/run.ts
+++ b/src/simulator/run.ts
@@ -1,10 +1,10 @@
 import {
-  instruction,
-  currentState,
   BYTES_PER_WORD,
+  currentState,
+  changeRunBit,
+  instruction,
   MEM_TEXT_START,
   NUM_INST,
-  changeRunBit,
 } from '../utils/constants';
 import {getInstInfo, memRead, memWrite, memWriteHalf} from '../utils/functions';
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,8 +1,8 @@
 import {
   initMemory,
   initInstInfo,
-  parseInstr,
   parseData,
+  parseInstr,
   parseSimulatorOutput,
   simulatorOutputType,
 } from './functions';

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -1,30 +1,7 @@
-import {
-  DEBUG,
-  pType,
-  SYMBOL_TABLE,
-  SymbolTableType,
-  MEM_NREGIONS,
-  memRegions,
-  MEM_GROW_UP,
-  RUN_BIT,
-  MIPS_REGS,
-  memData,
-  memStack,
-  MEM_DATA_START,
-  MEM_TEXT_START,
-  currentState,
-  instAddOne,
-  DEBUG_SET,
-  MEM_DUMP_SET,
-  instruction,
-  InstructionType,
-  INST_INFO,
-  pushCycle,
-  bcolors,
-} from './constants';
-import * as fs from 'fs';
 import path from 'path';
+import * as fs from 'fs';
 import {exit} from 'process';
+
 import {
   process_instruction,
   setFUNC,
@@ -36,6 +13,31 @@ import {
   setSHAMT,
   setTARGET,
 } from '../simulator/run';
+
+import {
+  bcolors,
+  currentState,
+  DEBUG,
+  DEBUG_SET,
+  INST_INFO,
+  instAddOne,
+  instruction,
+  InstructionType,
+  memData,
+  memStack,
+  memRegions,
+  MIPS_REGS,
+  MEM_GROW_UP,
+  MEM_DUMP_SET,
+  MEM_NREGIONS,
+  MEM_DATA_START,
+  MEM_TEXT_START,
+  pType,
+  pushCycle,
+  RUN_BIT,
+  SYMBOL_TABLE,
+  SymbolTableType,
+} from './constants';
 
 export interface simulatorOutputType {
   PC: string;


### PR DESCRIPTION
## ISSUE <#85> {서식 (import 구문) 리팩토링}
여기에 이슈에 대해서 간단하게 설명해주세요
import 구문 정리

빈 줄로 그룹지은 순서는,
1. 폴리필 (예: import ‘reflect-metadata’;)
2. Node 내장 모듈 (예: import fs from ‘fs’;)
3. 외부 모듈 (예: import { query } from ‘itiriri’;)
4. 내부 모듈 (예: import { UserService } from ‘src/services/userService’;)
5. 상위 디렉토리에서 불러오는 모듈 (예: import foo from ‘../foo’; import qux from ‘../../foo/qux’;)
6. 동일한 계층의 디렉토리에서 불러오는 모듈 (예: import bar from ‘./bar’; import baz from ‘./bar/baz’;)

import 내부
1. 알파벳 순서대로 배열 및 그룹화
2. 알파벳순서대로 그룹화 한 후, 같은 알파벳이 올 경우 작은 것부터 순서화


<br>

## CHANGES
변화가 있는 파일 

1. assembler.ts
2. constants.ts
3. functions.ts
4. run.ts


<br>

## TEST
어떤 부분을 테스트 해보면 좋을지 어떻게 테스트하면 되는지 간단하게 설명해주세요

## EX
예시 사진이 있다면 여기에 첨부해주세요
