### PR TITLE
Refact/104/assembler output string array

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ export function makeObjectFile(
 
 function for convert `assembly instructions` to `binary instructions`.
 
+> #### >= version 2.1.5
+>
+> `arrayOutputType` has deleted, assemble function only return string[] as output.
+
 > #### >= version 2.1.0
 >
 > `arrayOutputType` : if you want to get output with string, it should be false (default : true (string array))
@@ -73,14 +77,13 @@ function for convert `assembly instructions` to `binary instructions`.
 
 ```typescript
 interface IAssemble {
-  output: string[] | string;
+  output: string[];
   mappingDetail: IMapDetail[] | null;
 }
 
 export function assemble = (
   assemblyInstructions: string[],
-  arrayOutputType = true,
-  mappingDetailRequest = false,
+  mappingDetailRequest = false
 ) {
   ...
   return {output, mappingDetail} : IAssemble
@@ -385,6 +388,10 @@ In the browser, unlike in the local environment, only files or documents in the 
 
 ## Changes
 
+### >= version 2.1.5
+
+`arrayOutputType` has deleted, `assemble` function only return string[] as output.
+
 ### >= version 2.1.3
 
 #### new parameter for assemble `>= version 2.1.1`
@@ -410,50 +417,11 @@ In the browser, unlike in the local environment, only files or documents in the 
 - `output` => `{output, mappingDetail}` (in `assemble`)
 - `ISimulatorOutput | simulatorOutputType` => `ISimulatorOutput` (in `simulator`)
 
-```typescript
-interface IAssemble {
-  output: string[] | string;
-  mappingDetail: IMapDetail[] | null;
-}
-
-export function assemble = (
-  assemblyInstructions: string[],
-  arrayOutputType = true,
-  mappingDetailRequest = false,
-) {
-  ...
-  return {output, mappingDetail} : IAssemble
-};
-```
-
-```typescript
-export interface simulatorOutputType {
-  PC: string;
-  registers: {[key: string]: string};
-  dataSection: {[key: string]: string} | Record<string, never>;
-  stackSection: {[key: string]: string} | Record<string, never>;
-}
-
-export interface ISimulatorOutput {
-  result: simulatorOutputType;
-  history: simulatorOutputType[] | null;
-}
-
-export function simulator(
-  assemblyInstructions: string[],
-  cycleNum: number,
-  returnHistory = false,
-): Promise<ISimulatorOutput> {
-  ...
-  return  returnHistory ? {result, history: CYCLES} : {result, history: null};
-};
-```
-
 ## Supported Instruction
 
 you can check
 [**MIPS Reference**](https://inst.eecs.berkeley.edu/~cs61c/resources/MIPS_Green_Sheet.pdf)
-
+å
 In this library, we support below instructions
 
 | Instruction | Format | opcode | funct  |

--- a/index.ts
+++ b/index.ts
@@ -1,25 +1,19 @@
-import {
-  makeBinaryString,
-  makeBinaryObject,
-  makeBinaryArray,
-} from './src/simulator/assembler';
+import {makeBinaryObject, makeBinaryArray} from './src/simulator/assembler';
 import {initialize, initializeMem} from './src/utils/constants';
 import {
   IMapDetail,
   mainProcess,
-  makeInput,
   makeMappingDetail,
   simulatorOutputType,
 } from './src/utils/functions';
 
 interface IAssemble {
-  output: string[] | string;
+  output: string[];
   mappingDetail: IMapDetail[] | null;
 }
 
 export function assemble(
   assemblyInstructions: string[],
-  arrayOutputType = true,
   mappingDetailRequest = false,
 ): IAssemble {
   /*  
@@ -32,7 +26,7 @@ export function assemble(
    * Let your current directory is simulator (/Users/junghaejune/simulator).
    * Then you only put makeInput("sample_input", "example1.s") into assemblyInstructions
 
-   * output : output: string
+   * output: string[]
    * The assembly file is converted to a string in binary form.
     
     ex) 
@@ -44,10 +38,10 @@ export function assemble(
     ...
     
     output:
-    ...
-    00000010001000001000100000100100
-    00000010010000001001000000100100
-    ...
+    [00000010001000001000100000100100,
+      ...
+    00000010010000001001000000100100]
+
   */
 
   const {
@@ -69,7 +63,7 @@ export function assemble(
   // console.log('binaryData: ', binaryData);
   // console.log('mappingTable: ', mappingTable);
 
-  let output: string[] | string = makeBinaryArray(
+  const output: string[] = makeBinaryArray(
     dataSectionSize,
     textSectionSize,
     binaryText,
@@ -85,15 +79,6 @@ export function assemble(
       output,
     );
   }
-
-  if (arrayOutputType) return {output, mappingDetail};
-
-  output = makeBinaryString(
-    dataSectionSize,
-    textSectionSize,
-    binaryText,
-    binaryData,
-  );
 
   return {output, mappingDetail};
 }

--- a/tests/integration/assembler.test.ts
+++ b/tests/integration/assembler.test.ts
@@ -172,7 +172,7 @@ test(`testing example 1 for [mapping detail]`, () => {
   resetSymbolTable();
 
   const input = makeInput('sample_input', `example1.s`);
-  const {output, mappingDetail} = assemble(input, true, true);
+  const {mappingDetail} = assemble(input, true);
 
   expect(mappingDetail).toEqual(mappingDetailOutput);
 });
@@ -187,17 +187,6 @@ for (let i = 1; i <= 7; i++) {
       .split('\n') // 문자 -> 문자열 전환
       .filter(ele => ele); // "" 제거, ""는 false와 동일
 
-    expect(output).toEqual(testOutput);
-  });
-}
-
-for (let i = 1; i <= 7; i++) {
-  test(`testing example ${i} for [string output]`, () => {
-    resetSymbolTable();
-
-    const input = makeInput('sample_input', `example${i}.s`);
-    const {output} = assemble(input, false);
-    const testOutput = makeOutput('sample_output', `example${i}.o`);
     expect(output).toEqual(testOutput);
   });
 }


### PR DESCRIPTION
## ISSUE [#104] assembler output string[] 로 통일
assembler output string[] 로 통일


<br>

## CHANGES

### >= version 2.1.5

`arrayOutputType` has deleted, `assemble` function only return string[] as output.


```js
interface IAssemble {
  output: string[];
  mappingDetail: IMapDetail[] | null;
}

export function assemble(
  assemblyInstructions: string[],
  mappingDetailRequest = false,
): IAssemble {}
```

<br>
