### PR TITLE
[#109] fix : package-lock과 package의 버전 동기화 오류 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mips-simulator-js",
-  "version": "2.1.14",
+  "version": "2.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mips-simulator-js",
-      "version": "2.1.14",
+      "version": "2.1.7",
       "license": "MIT",
       "dependencies": {
         "ts-node": "^10.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mips-simulator-js",
-  "version": "2.1.5",
+  "version": "2.1.7",
   "description": "MIPS Simulator npm package",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## ISSUE <#109> fix : package-lock과 package의 버전 동기화 오류 해결
fix : package-lock과 package의 버전 동기화 오류 해결
CD 구축하는 과정에서 package-lock.json의 버전이 2.1.14로 되어있어 충돌 발생

<br>

## CHANGES
package-lock.json 삭제 후 다시 npm i 로 설치


<br>

