### PR TITLE
Feature/131/npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,8 @@ name: npm publish
 on:
   release:
     types: [created]
+    branches:
+      - main
 
 jobs:
   build:
@@ -44,3 +46,21 @@ jobs:
         run: npm run publish-npm
         env:
           NODE_AUTH_TOKEN: ${{secrets.mips_token}}
+
+  sync-release:
+  needs: publish-npm
+
+  runs-on: ubuntu-latest
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: main
+
+    - name: Merge release to main
+      uses: devmasx/merge-branch@master
+      with:
+        type: now
+        from_branch: release
+        target_branch: main
+        github_token: ${{ github.token }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,19 +48,19 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.mips_token}}
 
   sync-release:
-  needs: publish-npm
+    needs: publish-npm
 
-  runs-on: ubuntu-latest
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        ref: main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: main
 
-    - name: Merge release to main
-      uses: devmasx/merge-branch@master
-      with:
-        type: now
-        from_branch: release
-        target_branch: main
-        github_token: ${{ github.token }}
+      - name: Merge release to main
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: release
+          target_branch: main
+          github_token: ${{ github.token }}


### PR DESCRIPTION
## ISSUE <#131> {npm-publish.yml 수정}
npm-publish 수정


<br>

## CHANGES
1. on release branches: main 추가. release에서 선택하는건 여러가지가 될 수 있는데, main으로 release할 때만 워크플로가 진행된다고 함.
2. sync-release 추가, publish가 되면 release->main으로 자동 병합되도록 함.


<br>

## TEST
테스트를 해보고 싶은데, main 브랜치에 넣은 후에 진행할 수 있을 것 같아서 일단 PR로 올려놨어요. 
코드는 저번주에 merge할 때 있었던 코드여서 merge부분은 되는거 확인했는데, 
on release branches: main 부분이 main으로 release할 때만 workflow만 작동하는지에 대해서 확인해봐야할 것 같아요.

## EX
예시 사진이 있다면 여기에 첨부해주세요
