### PR TITLE
Feature/134/npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,6 +61,6 @@ jobs:
         uses: devmasx/merge-branch@master
         with:
           type: now
-          from_branch: release
-          target_branch: main
+          from_branch: main
+          target_branch: release
           github_token: ${{ github.token }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,8 @@ name: npm publish
 on:
   release:
     types: [created]
+    branches:
+      - main
 
 jobs:
   build:
@@ -44,3 +46,21 @@ jobs:
         run: npm run publish-npm
         env:
           NODE_AUTH_TOKEN: ${{secrets.mips_token}}
+
+  sync-release:
+    needs: publish-npm
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Merge release to main
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: release
+          target_branch: main
+          github_token: ${{ github.token }}


### PR DESCRIPTION
## ISSUE <#134> {npm-publish.yml main to release 수정}
기존 npm-publish.yml에서 배포하면 main->release로 머지하는 옵션 추가
main 브랜치에서 배포할 때만 action이 돌아가도록 변경


<br>

## CHANGES
어떤 코드를 만들었는지 혹은 어떤 코드를 수정해서 문제를 해결했는지 적어주세요


<br>

## TEST
어떤 부분을 테스트 해보면 좋을지 어떻게 테스트하면 되는지 간단하게 설명해주세요

## EX
예시 사진이 있다면 여기에 첨부해주세요
